### PR TITLE
Fix cmake warnings in move_group_interface_client

### DIFF
--- a/smacc_client_library/move_group_interface_client/CMakeLists.txt
+++ b/smacc_client_library/move_group_interface_client/CMakeLists.txt
@@ -104,8 +104,8 @@ find_package(Eigen3 REQUIRED)
 catkin_package(
   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIR}
   LIBRARIES move_group_interface_client ${YAML_CPP_LIBRARIES}
-  CATKIN_DEPENDS smacc moveit_ros_planning_interface 
-  DEPENDS Eigen3 yaml-cpp
+  CATKIN_DEPENDS smacc moveit_ros_planning_interface
+  DEPENDS EIGEN3 YAML_CPP
 )
 
 ###########


### PR DESCRIPTION
This fixes these two cmake warnings:

```
____________________________________________________________________________________________________
Warnings   << move_group_interface_client:cmake /home/tyler/code/ws_smacc/logs/move_group_interface_client/build.cmake.000.log
CMake Warning at /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'Eigen3' but neither 'Eigen3_INCLUDE_DIRS' nor
  'Eigen3_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:104 (catkin_package)


CMake Warning at /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'yaml-cpp' but neither 'yaml-cpp_INCLUDE_DIRS'
  nor 'yaml-cpp_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:104 (catkin_package)
```