### PR TITLE
Added checks to ClientBehavior updateables to avoid updates being executed before CB has finished initialising

### DIFF
--- a/smacc/include/smacc/smacc_client_behavior_base.h
+++ b/smacc/include/smacc/smacc_client_behavior_base.h
@@ -28,6 +28,8 @@ namespace smacc
 
         ros::NodeHandle getNode();
 
+        bool isInitialized();
+
     protected:
         virtual void runtimeConfigure();
 
@@ -64,5 +66,7 @@ namespace smacc
 
         friend class ISmaccState;
         friend class ISmaccOrthogonal;
+
+        bool initialized;
     };
 } // namespace smacc

--- a/smacc/src/smacc/signal_detector.cpp
+++ b/smacc/src/smacc/signal_detector.cpp
@@ -222,8 +222,12 @@ void SignalDetector::pollOnce()
           ROS_DEBUG_STREAM("updatable state elements: " << this->updatableStateElements_.size());
           for (auto *udpatableStateElement : this->updatableStateElements_)
           {
-            ROS_DEBUG_STREAM("pollOnce update client behavior call: " << demangleType(typeid(*udpatableStateElement)));
-            udpatableStateElement->executeUpdate();
+            auto stateElementBase = reinterpret_cast<ISmaccClientBehavior *>(udpatableStateElement);
+            if(stateElementBase->isInitialized())
+            {
+              ROS_DEBUG_STREAM("pollOnce update client behavior call: " << demangleType(typeid(*udpatableStateElement)));
+              udpatableStateElement->executeUpdate();
+            }
           }
         }
       }

--- a/smacc/src/smacc/smacc_client_behavior_base.cpp
+++ b/smacc/src/smacc/smacc_client_behavior_base.cpp
@@ -6,6 +6,7 @@ ISmaccClientBehavior::ISmaccClientBehavior()
 {
   stateMachine_ = nullptr;
   currentState = nullptr;
+  initialized = false;
 }
 
 ISmaccClientBehavior::~ISmaccClientBehavior()
@@ -34,18 +35,26 @@ ros::NodeHandle ISmaccClientBehavior::getNode()
 
 void ISmaccClientBehavior::executeOnEntry()
 {
+  initialized = false;
   ROS_DEBUG("[%s] Default empty SmaccClientBehavior onEntry", this->getName().c_str());
   this->onEntry();
+  initialized = true;
 }
 
 void ISmaccClientBehavior::executeOnExit()
 {
   ROS_DEBUG("[%s] Default empty SmaccClientBehavior onExit", this->getName().c_str());
   this->onExit();
+  initialized = false;
 }
 
 void ISmaccClientBehavior::dispose()
 {
+}
+
+bool ISmaccClientBehavior::isInitialized()
+{
+  return initialized;
 }
 
 }  // namespace smacc

--- a/smacc/src/smacc/smacc_updatable.cpp
+++ b/smacc/src/smacc/smacc_updatable.cpp
@@ -4,12 +4,12 @@ namespace smacc
 {
 
 ISmaccUpdatable::ISmaccUpdatable()
-    : lastUpdate_(0)
+    : lastUpdate_(ros::Time::now())
 {
 }
 
 ISmaccUpdatable::ISmaccUpdatable(ros::Duration duration)
-    : lastUpdate_(0),
+    : lastUpdate_(ros::Time::now()),
       periodDuration_(duration)
 {
 }


### PR DESCRIPTION
This PR is a fix to a bug/feature we encountered. 

We have a manually triggered state transition where updateable client behaviours can be initialised and destroyed at any time (similar to an interrupt). However, we found that at unpredictable  times, segfaults occur in the CB's update loop. Debugging showed that the CB's class members are called before they have properly been initialised. Indeed, [there don't seem to be any checks](https://github.com/reelrbtx/SMACC/blob/05f00f6504ff6c30ecf3865a27ec223ff3524225/smacc/src/smacc/signal_detector.cpp#L226) to see if the CBs' `onEntry` methods have finished executing and the class member initialised before their `executeUpdate` methods are called. 

To address this, I've added an `initialized` flag to the ClientBehavior base class and a corresponding check in the signal detector class. Furthermore, I've modified the time updateables are initialised with to use `ros::Time::now` instead of 0. The idea is to further reduce the risk of `executeUpdate` being called in the first update loop, though its not clear ow it will affect working with the ROS sim and real time clocks.

Potential issues:
1. Use of `reinterpret_cast` in update loop to cast to CB base class to access `initialized` flag may be slow. Potentially better to cache this once as is done for the updatable elements?
2. Not quite clear how modifying initial time values will affect working with ROS sim and other clocks. 

We implemented this fix in our own implementation (though slightly differently) and it seems to have fixed the issue we had. Hopefully someone else finds it helpful