### PR TITLE
Added additional init guard to prevent premature CB initialisation

### DIFF
--- a/smacc/src/smacc/signal_detector.cpp
+++ b/smacc/src/smacc/signal_detector.cpp
@@ -196,7 +196,8 @@ void SignalDetector::pollOnce()
     // STATE UPDATABLE ELEMENTS
     if (this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::TRANSITIONING &&
         this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_CONFIGURING &&
-        this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_EXITING)
+        this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_EXITING &&
+        this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_ENTERING)
     {
       // we do not update updatable elements during trasitioning or configuration of states
       long currentStateIndex = smaccStateMachine_->getCurrentStateCounter();


### PR DESCRIPTION
This is in response to the fix suggested in #60