### PR TITLE
get state reactor should return state reactor list instead of eventgenerator_

### DIFF
--- a/smacc/include/smacc/impl/smacc_state_impl.h
+++ b/smacc/include/smacc/impl/smacc_state_impl.h
@@ -181,7 +181,7 @@ namespace smacc
     TStateReactor* ISmaccState::getStateReactor()
     {
         TStateReactor* ret = nullptr;
-        for(auto& sr: this->eventGenerators_)
+        for(auto& sr: this->stateReactors_)
         {
             ret = dynamic_cast<TStateReactor *>(sr.get());
             if(ret!=nullptr)


### PR DESCRIPTION
get state reactor function returned the list of event generator