### PR TITLE
Ported fix for premature CB initalisation

### DIFF
--- a/smacc/src/smacc/signal_detector.cpp
+++ b/smacc/src/smacc/signal_detector.cpp
@@ -196,7 +196,8 @@ void SignalDetector::pollOnce()
     // STATE UPDATABLE ELEMENTS
     if (this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::TRANSITIONING &&
         this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_CONFIGURING &&
-        this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_EXITING)
+        this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_EXITING &&
+        this->smaccStateMachine_->stateMachineCurrentAction != StateMachineInternalAction::STATE_ENTERING)
     {
       // we do not update updatable elements during trasitioning or configuration of states
       long currentStateIndex = smaccStateMachine_->getCurrentStateCounter();


### PR DESCRIPTION
Porting over premature initialisation guard from #61

┆Issue is synchronized with this [Jira Task](https://robosoft-ai.atlassian.net/browse/SMACC1-12) by [Unito](https://www.unito.io)
