### PR TITLE
Implement smart pointers and signals2 tracking

### DIFF
--- a/smacc/include/smacc/client_bases/smacc_subscriber_client.h
+++ b/smacc/include/smacc/client_bases/smacc_subscriber_client.h
@@ -10,6 +10,8 @@
 #include <boost/optional/optional_io.hpp>
 #include <smacc/impl/smacc_state_impl.h>
 
+#include <memory>
+
 namespace smacc
 {
 
@@ -43,6 +45,7 @@ public:
   }
 
   smacc::SmaccSignal<void(const MessageType &)> onFirstMessageReceived_;
+  smacc::SmaccSignal<void()> testSignal;
   smacc::SmaccSignal<void(const MessageType &)> onMessageReceived_;
 
   std::function<void(const MessageType &)> postMessageEvent;
@@ -52,6 +55,20 @@ public:
   boost::signals2::connection onMessageReceived(void (T::*callback)(const MessageType &), T *object)
   {
     return this->getStateMachine()->createSignalConnection(onMessageReceived_, callback, object);
+  }
+
+  // TODO: Why does the compiler moan when we only use T? They're the same type T==F
+  template <typename T, typename F>
+  boost::signals2::connection onMessageReceived(void (T::*callback)(const MessageType &), std::shared_ptr<F> object)
+  {
+    return this->getStateMachine()->createSignalConnectionNew(onMessageReceived_, std::bind(callback, object.get(), std::placeholders::_1), object);
+  }
+
+
+  template <typename T>
+  boost::signals2::connection onMessageReceived(std::function<void(const MessageType&)> callback, std::shared_ptr<T> object)
+  {
+    return this->getStateMachine()->createSignalConnectionNew(onMessageReceived_, callback, object);
   }
 
   template <typename T>

--- a/smacc/include/smacc/impl/smacc_client_behavior_impl.h
+++ b/smacc/include/smacc/impl/smacc_client_behavior_impl.h
@@ -75,6 +75,19 @@ void ISmaccClientBehavior::requiresComponent(SmaccComponentType *&storage)
     }
 }
 
+template <typename SmaccComponentType>
+std::shared_ptr<SmaccComponentType> ISmaccClientBehavior::requiresComponent()
+{
+    if (stateMachine_ == nullptr)
+    {
+        ROS_ERROR("Cannot use the requiresComponent funcionality before assigning the client behavior to an orthogonal. Try using the OnEntry method to capture required components.");
+    }
+    else
+    {
+        return stateMachine_->requiresComponent<SmaccComponentType>();
+    }
+}
+
 template <typename TOrthogonal, typename TSourceObject>
 void ISmaccClientBehavior::onOrthogonalAllocation() {}
 

--- a/smacc/include/smacc/impl/smacc_client_behavior_impl.h
+++ b/smacc/include/smacc/impl/smacc_client_behavior_impl.h
@@ -56,6 +56,12 @@ void ISmaccClientBehavior::requiresClient(SmaccClientType *&storage)
     currentOrthogonal->requiresClient(storage);
 }
 
+template <typename SmaccClientType>
+std::shared_ptr<SmaccClientType> ISmaccClientBehavior::requiresClient()
+{
+    return currentOrthogonal->requiresClient<SmaccClientType>();
+}
+
 template <typename SmaccComponentType>
 void ISmaccClientBehavior::requiresComponent(SmaccComponentType *&storage)
 {

--- a/smacc/include/smacc/impl/smacc_client_impl.h
+++ b/smacc/include/smacc/impl/smacc_client_impl.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <smacc/smacc_client.h>
 #include <smacc/impl/smacc_state_machine_impl.h>
 
@@ -41,6 +42,30 @@ namespace smacc
             if (tcomponent != nullptr)
             {
                 return tcomponent;
+            }
+        }
+
+        return nullptr;
+    }
+
+    template <typename TComponent>
+    std::shared_ptr<TComponent> ISmaccClient::getComponentNew() 
+    {
+        return this->getComponentNew<TComponent>(std::string());
+    }
+
+    template <typename TComponent>
+    std::shared_ptr<TComponent> ISmaccClient::getComponentNew(std::string name)
+    {
+        for(auto &component : components_)
+        {
+            if(component.first.name != name)
+              continue;
+
+            auto cast_component = std::dynamic_pointer_cast<TComponent>(component.second);
+            if(cast_component != nullptr)
+            {
+                return cast_component;
             }
         }
 

--- a/smacc/include/smacc/impl/smacc_state_machine_impl.h
+++ b/smacc/include/smacc/impl/smacc_state_machine_impl.h
@@ -133,6 +133,30 @@ namespace smacc
 
     // storage = ret;
   }
+
+  template <typename SmaccComponentType>
+  std::shared_ptr<SmaccComponentType> ISmaccStateMachine::requiresComponent()
+  {
+    ROS_DEBUG("component %s is required", demangleSymbol(typeid(SmaccComponentType).name()).c_str());
+    std::lock_guard<std::recursive_mutex> lock(m_mutex_);
+
+    for (auto ortho : this->orthogonals_)
+    {
+      for (auto &client : ortho.second->clients_)
+      {
+
+        auto component = client->getComponent<SmaccComponentType>();
+        if (component != nullptr)
+        {
+          return component;
+        }
+      }
+    }
+
+    ROS_WARN("component %s is required but it was not found in any orthogonal", demangleSymbol(typeid(SmaccComponentType).name()).c_str());
+
+    return nullptr;
+  }
   //-------------------------------------------------------------------------------------------------------
   template <typename EventType>
   void ISmaccStateMachine::postEvent(EventType *ev, EventLifeTime evlifetime)

--- a/smacc/include/smacc/impl/smacc_state_machine_impl.h
+++ b/smacc/include/smacc/impl/smacc_state_machine_impl.h
@@ -370,9 +370,16 @@ namespace smacc
                       std::is_base_of<ISmaccComponent, TSmaccObjectType>::value,
                   "Only are accepted smacc types as subscribers for smacc signals");
 
-    typedef decltype(callback) ft;
-    Bind<boost::function_types::function_arity<ft>::value> binder;
-    boost::signals2::connection connection = binder.bindaux(signal, callback, object.get()).track(object);
+    // typedef decltype(callback) ft;
+    // typedef typename decltype(signal)::SmaccSignalType st;
+    // Bind<boost::function_types::function_arity<ft>::value> binder;
+    // auto test = decltype(signal)::SmaccSignalSlotType(callback, object.get(), _1).track(object);
+    // auto test = std::bind(callback, object.get(), _1);
+    // boost::signals2::connection connection = signal.connect(decltype(signal)::SmaccSlotType(callback, object.get(), _1).track(object));
+    // boost::signals2::connection connection = signal.connect(typename TSmaccSignal::SmaccSlotType(callback, object.get(), _1).track(object));
+    boost::signals2::connection connection = signal.connect(typename TSmaccSignal::SmaccSlotType(callback).track_foreign(object));
+    // boost::signals2::connection connection = signal.connect(std::bind(callback, object.get(), _1).track(object));
+    // boost::signals2::connection connection = signal.connect(test.track(object));
 
     // long life-time objects
     if (std::is_base_of<ISmaccComponent, TSmaccObjectType>::value ||

--- a/smacc/include/smacc/smacc_client.h
+++ b/smacc/include/smacc/smacc_client.h
@@ -56,6 +56,12 @@ public:
     template <typename TComponent>
     TComponent *getComponent(std::string name);
 
+    template <typename TComponent>
+    std::shared_ptr<TComponent> getComponentNew();
+
+    template <typename TComponent>
+    std::shared_ptr<TComponent> getComponentNew(std::string name);
+
     virtual smacc::introspection::TypeInfo::Ptr getType();
 
     inline ISmaccStateMachine *getStateMachine();

--- a/smacc/include/smacc/smacc_client_behavior_base.h
+++ b/smacc/include/smacc/smacc_client_behavior_base.h
@@ -23,6 +23,9 @@ namespace smacc
         template <typename SmaccClientType>
         void requiresClient(SmaccClientType *&storage);
 
+        template <typename SmaccClientType>
+        std::shared_ptr<SmaccClientType> requiresClient();
+
         template <typename SmaccComponentType>
         void requiresComponent(SmaccComponentType *&storage);
 

--- a/smacc/include/smacc/smacc_client_behavior_base.h
+++ b/smacc/include/smacc/smacc_client_behavior_base.h
@@ -29,6 +29,9 @@ namespace smacc
         template <typename SmaccComponentType>
         void requiresComponent(SmaccComponentType *&storage);
 
+        template <typename SmaccComponentType>
+        std::shared_ptr<SmaccComponentType> requiresComponent();
+
         ros::NodeHandle getNode();
 
     protected:

--- a/smacc/include/smacc/smacc_orthogonal.h
+++ b/smacc/include/smacc/smacc_orthogonal.h
@@ -31,6 +31,9 @@ public:
     void requiresComponent(SmaccComponentType *&storage);
 
     template <typename SmaccClientType>
+    std::shared_ptr<SmaccClientType> requiresClient();
+
+    template <typename SmaccClientType>
     bool requiresClient(SmaccClientType *&storage);
 
     inline const std::vector<std::shared_ptr<smacc::ISmaccClient>> &getClients();

--- a/smacc/include/smacc/smacc_signal.h
+++ b/smacc/include/smacc/smacc_signal.h
@@ -24,5 +24,9 @@ template <typename Signature,
           typename Mutex = boost::signals2::mutex>
 class SmaccSignal : public boost::signals2::signal<Signature, Combiner, Group, GroupCompare, SlotFunction, ExtendedSlotFunction, Mutex>
 {
+  public:
+    typedef typename boost::signals2::signal<Signature, Combiner, Group, GroupCompare, SlotFunction, ExtendedSlotFunction, Mutex> SmaccSignalType;
+    typedef typename SmaccSignalType::slot_type SmaccSlotType;
+
 };
 } // namespace smacc

--- a/smacc/include/smacc/smacc_state_machine.h
+++ b/smacc/include/smacc/smacc_state_machine.h
@@ -67,6 +67,9 @@ public:
     template <typename SmaccComponentType>
     void requiresComponent(SmaccComponentType *&storage);
 
+    template <typename SmaccComponentType>
+    std::shared_ptr<SmaccComponentType> requiresComponent();
+
     template <typename EventType>
     void postEvent(EventType *ev, EventLifeTime evlifetime = EventLifeTime::ABSOLUTE);
 

--- a/smacc/include/smacc/smacc_state_machine.h
+++ b/smacc/include/smacc/smacc_state_machine.h
@@ -103,6 +103,9 @@ public:
     template <typename TSmaccSignal, typename TMemberFunctionPrototype, typename TSmaccObjectType>
     boost::signals2::connection createSignalConnection(TSmaccSignal &signal, TMemberFunctionPrototype callback, TSmaccObjectType *object);
 
+    template <typename TSmaccSignal, typename TMemberFunctionPrototype, typename TSmaccObjectType>
+    boost::signals2::connection createSignalConnectionNew(TSmaccSignal &signal, TMemberFunctionPrototype callback, std::shared_ptr<TSmaccObjectType> object);
+
     // template <typename TSmaccSignal, typename TMemberFunctionPrototype>
     // boost::signals2::connection createSignalConnection(TSmaccSignal &signal, TMemberFunctionPrototype callback);
 

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/client_behaviors/cb_my_subscriber_behavior.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/client_behaviors/cb_my_subscriber_behavior.h
@@ -1,6 +1,7 @@
 
 #pragma once
 #include <sm_ferrari/clients/cl_subscriber/cl_subscriber.h>
+#include <memory>
 
 namespace sm_ferrari
 {
@@ -13,18 +14,25 @@ struct EvMyBehavior: sc::event<EvMyBehavior<TSource, TOrthogonal>>
 
 };
 
-class CbMySubscriberBehavior : public smacc::SmaccClientBehavior
+class CbMySubscriberBehavior : public smacc::SmaccClientBehavior, public std::enable_shared_from_this<CbMySubscriberBehavior>
 {
 public:
     void onEntry()
     {
-        ROS_ERROR("ALLO");
         std::weak_ptr<ClSubscriber> client = this->requiresClient<ClSubscriber>();
 
         if(auto locked_client = client.lock())
         {
-            ROS_ERROR("LOCKED");
-            locked_client->onMessageReceived(&CbMySubscriberBehavior::onMessageReceived, this);
+            // locked_client->onMessageReceived(&CbMySubscriberBehavior::onMessageReceived, this);
+            //locked_client->onMessageReceived([&](const std_msgs::Float32& msg) -> void 
+            //{
+            //    if(msg.data > 30)
+            //    {
+            //        ROS_INFO("[CbMySubscriberBehavior] received message from topic with value > 30. Posting event!");
+            //        this->postMyEvent_();
+            //    }
+            //}, shared_from_this());
+            locked_client->onMessageReceived(&CbMySubscriberBehavior::onMessageReceived, shared_from_this());
         }
     }
 

--- a/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/client_behaviors/cb_my_subscriber_behavior.h
+++ b/smacc_sm_reference_library/sm_ferrari/include/sm_ferrari/clients/cl_subscriber/client_behaviors/cb_my_subscriber_behavior.h
@@ -18,10 +18,14 @@ class CbMySubscriberBehavior : public smacc::SmaccClientBehavior
 public:
     void onEntry()
     {
-        ClSubscriber* client;
-        this->requiresClient(client);
+        ROS_ERROR("ALLO");
+        std::weak_ptr<ClSubscriber> client = this->requiresClient<ClSubscriber>();
 
-        client->onMessageReceived(&CbMySubscriberBehavior::onMessageReceived, this);
+        if(auto locked_client = client.lock())
+        {
+            ROS_ERROR("LOCKED");
+            locked_client->onMessageReceived(&CbMySubscriberBehavior::onMessageReceived, this);
+        }
     }
 
     template <typename TOrthogonal, typename TSourceObject>


### PR DESCRIPTION
This is an experimental branch to solve some of the issues we've been facing, described in #57 and #86 

Basically, I've added the ability to gain access to clients from CBs as `std::weak_ptr`s rather than raw pointers. Since they were saved as `std::shared_ptr`s already within the state machine, it was a pretty straight-forward change. 

The main change is using `boost::signals2` tracking facility to automatically monitor and control a slot's lifetime based on when the owning CB goes out of scope. Early tests show that this might prevents the issue we've been facing where member variables are being access from a CB callback _after_ the callback has been deallocated upon state transitions. 

Both these changes have been integrated in a small part within the `sm_ferrari` example's CB if you wanted to see the intended usage

This is very much WIP and a lot needs to be refined. Opening up this PR for visibility and comments

┆Issue is synchronized with this [Jira Task](https://robosoft-ai.atlassian.net/browse/SMACC1-29) by [Unito](https://www.unito.io)
