### PR TITLE
Update CI.yaml

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   CI:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: ros-tooling/setup-ros@v0.3


### PR DESCRIPTION
Looks like Ubuntu 20.04 isn't working anymore with Github Actions

┆Issue is synchronized with this [Jira Task](https://robosoft-ai.atlassian.net/browse/SMACC1-33) by [Unito](https://www.unito.io)
